### PR TITLE
WIP: Add Support for Marshaling More Types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/strongswan/govici
+
+go 1.13

--- a/message.go
+++ b/message.go
@@ -998,7 +998,16 @@ func (m *Message) unmarshalField(field reflect.Value, rv reflect.Value) error {
 			return fmt.Errorf("%v: %v", errUnmarshalNonMessage, rv.Type())
 		}
 
-		return msg.unmarshal(field.Interface())
+		fp := field
+		if field.IsNil() {
+			fp = reflect.New(field.Type().Elem())
+		}
+
+		if err := msg.unmarshal(fp.Interface()); err != nil {
+			return err
+		}
+
+		field.Set(fp)
 
 	case reflect.Struct:
 		msg, ok := rv.Interface().(*Message)

--- a/message.go
+++ b/message.go
@@ -785,6 +785,11 @@ func (m *Message) marshalFromMap(rv reflect.Value) error {
 }
 
 func (m *Message) marshalField(name string, rv reflect.Value) error {
+
+	if rv.Kind() == reflect.Interface {
+		rv = reflect.ValueOf(rv)
+	}
+
 	switch rv.Kind() {
 
 	case reflect.String:
@@ -874,7 +879,7 @@ func (m *Message) unmarshalField(field reflect.Value, rv reflect.Value) error {
 			return fmt.Errorf("%v: string and %v", errUnmarshalTypeMismatch, rv.Type())
 		}
 		field.Set(rv)
-		
+
 	case reflect.Slice:
 		if _, ok := rv.Interface().([]string); !ok {
 			return fmt.Errorf("%v: []string and %v", errUnmarshalTypeMismatch, rv.Type())

--- a/message.go
+++ b/message.go
@@ -777,10 +777,7 @@ func (m *Message) marshalFromMap(rv reflect.Value) error {
 
 		k := iter.Key()
 		v := iter.Value()
-		tmp := reflect.TypeOf(v)
-		fmt.Println(tmp)
-		_, ok := v.Interface().(*Message)
-		fmt.Println(ok)
+
 		err := m.marshalField(k.String(), v)
 		if err != nil {
 			return err

--- a/message.go
+++ b/message.go
@@ -79,7 +79,8 @@ var (
 	errUnmarshalBadType      = fmt.Errorf("%v: type must be non-nil pointer", errUnmarshal)
 	errUnmarshalTypeMismatch = fmt.Errorf("%v: incompatible types", errUnmarshal)
 	errUnmarshalNonMessage   = fmt.Errorf("%v: encountered non-message type", errUnmarshal)
-)
+	errUnmarshalUnsupportedType = fmt.Errorf("%v: encountered unsupported type", errUnmarshal))
+
 
 // MessageStream is used to feed continuous data during a command request, and simply
 // contains a slice of *Message.
@@ -912,7 +913,11 @@ func (m *Message) unmarshalField(field reflect.Value, rv reflect.Value) error {
 		}
 
 		field.Set(reflect.Indirect(fp))
+
+	default:
+		return fmt.Errorf("%v: %v", errUnmarshalUnsupportedType, field.Kind())
 	}
+
 
 	return nil
 }

--- a/message.go
+++ b/message.go
@@ -777,7 +777,10 @@ func (m *Message) marshalFromMap(rv reflect.Value) error {
 
 		k := iter.Key()
 		v := iter.Value()
-
+		tmp := reflect.TypeOf(v)
+		fmt.Println(tmp)
+		_, ok := v.Interface().(*Message)
+		fmt.Println(ok)
 		err := m.marshalField(k.String(), v)
 		if err != nil {
 			return err
@@ -790,7 +793,7 @@ func (m *Message) marshalFromMap(rv reflect.Value) error {
 func (m *Message) marshalField(name string, rv reflect.Value) error {
 
 	if rv.Kind() == reflect.Interface {
-		rv = reflect.ValueOf(rv)
+		rv = reflect.ValueOf(rv.Interface())
 	}
 
 	switch rv.Kind() {

--- a/message.go
+++ b/message.go
@@ -1001,13 +1001,12 @@ func (m *Message) unmarshalField(field reflect.Value, rv reflect.Value) error {
 		fp := field
 		if field.IsNil() {
 			fp = reflect.New(field.Type().Elem())
+			field.Set(fp)
 		}
 
 		if err := msg.unmarshal(fp.Interface()); err != nil {
 			return err
 		}
-
-		field.Set(fp)
 
 	case reflect.Struct:
 		msg, ok := rv.Interface().(*Message)


### PR DESCRIPTION
This is currently a WIP.

- [ ] Marshal for Maps
- [ ] Unmarshal for Maps
- [X] Marshal for Booleans
- [x] Unmarshal for Booleans
- [x] Marshal for Integers
- [x] Unmarshal for Integers
- [ ] Support Enumed String Types (for example, `type MyType string`)

- [ ] Expand Tests
- [ ] Documentation and Docstrings
---

Allow for the use of more natural Go-types when defining Vici configuration structures. In addition, maps with string-like keys may now be used for marshaling configuration for both top-level or struct-fields. This aids in dealing with configuration structure which may not be known at run-time, without having to deal the the Vici Message type directly.

For example:

```go
configAsMap := map[string]interface{} {
	"version": 0,
	"children": map[string]string {
		"local_ts": "0.0.0.0/0",
	},
}

msg, err := vici.MarshalMessage(configAsMap)
```